### PR TITLE
Allow anyone to CLOSE campaigns in withdraw period

### DIFF
--- a/test/routes.js
+++ b/test/routes.js
@@ -383,7 +383,7 @@ tape('should prevent submitting events for a channel in withdraw period', async 
 	const resp = await postEvents(followerUrl, channel.id, genEvents(1)).then(r => r.json())
 	t.equal(
 		resp.message,
-		'channel is past withdraw period',
+		'channel is in withdraw period',
 		'should prevent events after withdraw period'
 	)
 	// @TODO we can still submit validator messages

--- a/test/routes.js
+++ b/test/routes.js
@@ -386,7 +386,10 @@ tape('should prevent submitting events for a channel in withdraw period', async 
 		'channel is in withdraw period',
 		'should prevent events after withdraw period'
 	)
-	// @TODO we can still submit validator messages
+
+	// we can still submit an un-authenticated CLOSE while we're in the withdraw period
+	const closeHttpResp = await postEvents(followerUrl, channel.id, [{ type: 'CLOSE' }], null)
+	t.equal(closeHttpResp.status, 200, 'we can still CLOSE')
 
 	t.end()
 })


### PR DESCRIPTION
This will close #228 

it will allow the relayer to trigger closing of the campaign automatically once it reaches a withdraw period