### PR TITLE
Version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adex-validator-stack",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adex-validator-stack",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adex-validator-stack",
-  "version": "0.5.17",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adex-validator-stack",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "AdEx Validator stack (sentry, validator worker, watcher)",
   "main": "bin/sentry.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adex-validator-stack",
-  "version": "0.5.17",
+  "version": "0.6.0",
   "description": "AdEx Validator stack (sentry, validator worker, watcher)",
   "main": "bin/sentry.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adex-validator-stack",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "AdEx Validator stack (sentry, validator worker, watcher)",
   "main": "bin/sentry.js",
   "scripts": {

--- a/services/sentry/lib/access.js
+++ b/services/sentry/lib/access.js
@@ -72,8 +72,7 @@ async function checkAccess(channel, session, events) {
 				if (events.length !== 1) {
 					return new Error('rateLimit: only allows 1 event')
 				}
-				const prefix = events[0].type === 'CLICK' ? 'adexRateLimitClick' : 'adexRateLimit'
-				key = `${prefix}:${channel.id}:${session.ip}`
+				key = `adexRateLimit:${channel.id}:${events[0].type}:${session.ip}`
 			} else {
 				// unsupported limit type
 				return null

--- a/services/sentry/lib/access.js
+++ b/services/sentry/lib/access.js
@@ -59,7 +59,6 @@ async function checkAccess(channel, session, events) {
 
 	const ifErr = await Promise.all(
 		rules.map(async rule => {
-			// Matching rule has no rateLimit, so we're good
 			if (!rule.rateLimit) return null
 
 			const type = rule.rateLimit.type
@@ -73,7 +72,8 @@ async function checkAccess(channel, session, events) {
 				if (events.length !== 1) {
 					return new Error('rateLimit: only allows 1 event')
 				}
-				key = `adexRateLimit:${channel.id}:${session.ip}`
+				const prefix = events[0].type === 'CLICK' ? 'adexRateLimitClick' : 'adexRateLimit'
+				key = `${prefix}:${channel.id}:${session.ip}`
 			} else {
 				// unsupported limit type
 				return null


### PR DESCRIPTION
bumping to 0.6

compared to the 0.6 draft, we're missing:
- Ability to update impression price dynamically, allowing real-time header bidding 
- Ability to pause channels/campaigns

but we also have
- even more advanced /analytics
- Cloudflare Origin CA added to the repo, so it's built into the Docker image
- bugfixes: namely the eventReducer 0 fix (cea6df4453bb8a701980b0151a8ffa7235fdc457) 
- tracking CLICK
- fixed #227 #47 

and some things we're not gonna add:
- Pay event, allowing the channel creator to arbitrarily pay anyone; this allows unhealthy channels to "catch up" and regain health
- statistics by ad unit
