### PR TITLE
ethereum adapter: support counterfactual accounts

### DIFF
--- a/adapters/ethereum/index.js
+++ b/adapters/ethereum/index.js
@@ -98,10 +98,9 @@ function Adapter(opts, cfg, ethProvider) {
 		// @TODO: validate era here too
 		let sess = { era: payload.era }
 		if (typeof payload.identity === 'string' && payload.identity.length === 42) {
-			const identitiesOwned = await fetch(
-				`${cfg.ETHEREUM_ADAPTER_RELAYER}/identity/by-owner/${from}`
-			).then(r => r.json())
-			const privEntry = Object.entries(identitiesOwned || {}).find(
+			const relayerUrl = `${cfg.ETHEREUM_ADAPTER_RELAYER}/identity/by-owner/${from}`
+			const identitiesOwned = await fetch(relayerUrl).then(r => r.json())
+			const privEntry = Object.entries(identitiesOwned).find(
 				([k, v]) => k.toLowerCase() === payload.identity.toLowerCase() && v
 			)
 			if (!privEntry) return Promise.reject(new Error('insufficient privilege'))

--- a/cfg/dev.js
+++ b/cfg/dev.js
@@ -19,5 +19,6 @@ module.exports = {
 	MINIMAL_FEE: 0,
 	ETHEREUM_CORE_ADDR: '0x333420fc6a897356e69b62417cd17ff012177d2b',
 	ETHEREUM_NETWORK: 'goerli',
+	ETHEREUM_ADAPTER_RELAYER: 'https://goerli-relayer.adex.network',
 	VALIDATORS_WHITELIST: []
 }

--- a/cfg/prod.js
+++ b/cfg/prod.js
@@ -22,5 +22,6 @@ module.exports = {
 	],
 	ETHEREUM_CORE_ADDR: '0x333420fc6a897356e69b62417cd17ff012177d2b',
 	ETHEREUM_NETWORK: 'homestead',
+	ETHEREUM_ADAPTER_RELAYER: 'https://relayer.adex.network',
 	VALIDATORS_WHITELIST: []
 }


### PR DESCRIPTION
do not call the contract directly to check auth - call the relayer instead