### PR TITLE
AIP22: address format consolidation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ services:
         - redis
 language: node_js
 node_js:
-        - "10"
+        - "12"
 before_script:
         - mkdir -p ./database 
         - mongod --fork --logpath /dev/null --dbpath ./database

--- a/adapters/dummy/index.js
+++ b/adapters/dummy/index.js
@@ -1,4 +1,5 @@
 const { MerkleTree, Channel } = require('adex-protocol-eth/js')
+const { getAddress } = require('ethers').utils
 const assert = require('assert')
 const dummyVals = require('../../test/prep-db/mongo')
 const lib = require('../lib')
@@ -55,6 +56,10 @@ function Adapter(opts, cfg) {
 		if (who) return Promise.resolve(dummyVals.auth[who[0]])
 		return Promise.reject(new Error(`no auth token for this identity: ${identity}`))
 	}
+}
+
+Adapter.prototype.getAddress = function(addr) {
+	return getAddress(addr)
 }
 
 Adapter.prototype.getBalanceLeaf = function(acc, bal) {

--- a/adapters/ethereum/index.js
+++ b/adapters/ethereum/index.js
@@ -129,6 +129,10 @@ function Adapter(opts, cfg, ethProvider) {
 	}
 }
 
+Adapter.prototype.getAddress = function(addr) {
+	return formatAddress(addr)
+}
+
 Adapter.prototype.getBalanceLeaf = function(acc, bal) {
 	return Channel.getBalanceLeaf(acc, bal)
 }

--- a/routes/schemas.js
+++ b/routes/schemas.js
@@ -164,7 +164,7 @@ module.exports = {
 						})
 					)
 					.required()
-			})
+			}).required()
 		)
 	},
 	eventTimeAggr: {

--- a/services/validatorWorker/lib/mergeAggrs.js
+++ b/services/validatorWorker/lib/mergeAggrs.js
@@ -4,8 +4,7 @@ const { toBNStringMap, toBNMap } = require('./')
 const { getBalancesAfterFeesTree } = require('./fees')
 
 // Pure, should not mutate inputs
-// mergeAggrs(accounting, aggrs, channel) -> { balances, newAccounting }
-// `balances` is the same as newAccounting.balances, but a BN map
+// mergeAggrs(accounting, aggrs, channel) -> newAccounting
 function mergeAggrs(accounting, aggrs, channel) {
 	const depositAmount = new BN(channel.depositAmount, 10)
 	const newAccounting = {
@@ -33,7 +32,7 @@ function mergeAggrs(accounting, aggrs, channel) {
 	const balances = getBalancesAfterFeesTree(balancesBeforeFees, channel)
 	newAccounting.balances = toBNStringMap(balances)
 
-	return { balances, newAccounting }
+	return newAccounting
 }
 
 // mergePayoutsIntoBalances: pure, (balances, events, depositAmount) -> newBalances

--- a/services/validatorWorker/producer.js
+++ b/services/validatorWorker/producer.js
@@ -1,5 +1,4 @@
 const { mergeAggrs } = require('./lib/mergeAggrs')
-const { toBNMap } = require('./lib')
 const logger = require('../logger')('validatorWorker(producer)')
 
 async function tick(iface, channel) {
@@ -16,11 +15,11 @@ async function tick(iface, channel) {
 	// and produce a new accounting message
 	if (aggrs.length) {
 		logMerge(aggrs, channel)
-		const { balances, newAccounting } = mergeAggrs(accounting, aggrs, channel)
+		const newAccounting = mergeAggrs(accounting, aggrs, channel)
 		await iface.propagate([newAccounting])
-		return { balances, newAccounting }
+		return { accounting, newAccounting }
 	}
-	return { balances: toBNMap(accounting.balances) }
+	return { accounting }
 }
 
 function logMerge(aggrs, channel) {

--- a/test/index.js
+++ b/test/index.js
@@ -272,12 +272,7 @@ tape('should merge event aggrs and apply fees', function(t) {
 		depositAmount: '10000'
 	}
 	const balancesBeforeFees = { a: '100', b: '200' }
-	const { balances, newAccounting } = mergeAggrs(
-		{ balancesBeforeFees },
-		[genEvAggr(5, 'a')],
-		channel
-	)
-	t.deepEqual(toBNStringMap(balances), newAccounting.balances, 'balances is the same')
+	const newAccounting = mergeAggrs({ balancesBeforeFees }, [genEvAggr(5, 'a')], channel)
 	t.equal(newAccounting.balancesBeforeFees.a, '150', 'balance of recepient incremented accordingly')
 	t.equal(newAccounting.balances.a, '148', 'balanceAfterFees is ok')
 	t.end()
@@ -290,12 +285,7 @@ tape('should never allow exceeding the deposit', function(t) {
 	}
 	const depositAmount = new BN(channel.depositAmount, 10)
 	const balancesBeforeFees = { a: '100', b: '200' }
-	const { balances, newAccounting } = mergeAggrs(
-		{ balancesBeforeFees },
-		[genEvAggr(1001, 'a')],
-		channel
-	)
-	t.deepEqual(toBNStringMap(balances), newAccounting.balances, 'balances is the same')
+	const newAccounting = mergeAggrs({ balancesBeforeFees }, [genEvAggr(1001, 'a')], channel)
 	t.equal(
 		newAccounting.balancesBeforeFees.a,
 		'9800',

--- a/test/integration.js
+++ b/test/integration.js
@@ -42,7 +42,9 @@ function aggrAndTick() {
 tape('submit events and ensure they are accounted for', async function(t) {
 	// the CLICK is not paid for by default
 	// the IMPRESSION, however, pays 1 by default
-	const evs = genEvents(3)
+	// We use .toLowerCase() to also test if the balance tree contains properly checksummed addrs
+	const evs = genEvents(2, defaultPubName.toLowerCase())
+		.concat(genEvents(1, defaultPubName))
 		.concat(genEvents(2, randomAddress()))
 		.concat(genEvents(1, randomAddress(), 'CLICK'))
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 const tape = require('tape-catch')
 const fetch = require('node-fetch')
+const { getAddress } = require('ethers').utils
 const { Channel, MerkleTree } = require('adex-protocol-eth/js')
 const { getStateRootHash } = require('../services/validatorWorker/lib')
 const SentryInterface = require('../services/validatorWorker/lib/sentryInterface')
@@ -21,7 +22,7 @@ const postEvsAsCreator = (url, id, ev) => postEvents(url, id, ev, dummyVals.auth
 
 const leaderUrl = dummyVals.channel.spec.validators[0].url
 const followerUrl = dummyVals.channel.spec.validators[1].url
-const defaultPubName = dummyVals.ids.publisher
+const defaultPubName = getAddress(dummyVals.ids.publisher)
 
 let dummyAdapter = require('../adapters/dummy')
 
@@ -414,7 +415,7 @@ tape('should close channel', async function(t) {
 	// check the creator is awarded the remaining token balance
 	const { balances } = await channelIface.getOurLatestMsg('Accounting')
 	t.equal(
-		balances[dummyVals.auth.creator],
+		balances[getAddress(dummyVals.auth.creator)],
 		'792',
 		'creator balance should be remaining channel deposit minus fees'
 	)


### PR DESCRIPTION
This PR changes SentryInterface so that it sanitizes all msgs/eventAggregates before they enter the validatorWorker, to validate and checksum all addresses.

This consolidates the address format across all our components to a checksummed format.

Current tests are sufficient, because we check for `getAddress(dummyVals.ids.publisher)` in the balance tree but the events we sent are with `dummyVals.ids.publisher`