### PR TITLE
Analytics: minor segmentByChannel improvements

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -333,7 +333,7 @@ Submit channel events to a validator sentry
 
 ## Analytics
 
-All routes take `period` (string, can be "month", "week", "day"), `start`/`end` (optional ISO string dates)
+All routes take `timeframe` (string, can be "month", "week", "day"), `start`/`end` (optional ISO string dates)
 
 #### Global Analytics
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adex-validator-stack",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adex-validator-stack",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "AdEx Validator stack (sentry, validator worker, watcher)",
   "main": "bin/sentry.js",
   "scripts": {

--- a/routes/analytics.js
+++ b/routes/analytics.js
@@ -93,14 +93,14 @@ function analytics(req, advertiserChannels, skipPublisherFiltering) {
 		$subtract: [{ $toLong: '$created' }, { $mod: [{ $toLong: '$created' }, span] }]
 	}
 	const group = {
-		_id: segmentByChannel ? { time: timeGroup, channelId: '$channelId' } : timeGroup,
+		_id: segmentByChannel ? { time: timeGroup, channelId: '$channelId' } : { time: timeGroup },
 		value: { $sum: '$value' }
 	}
-	const resultProjection = { value: '$value', time: '$_id', _id: 0 }
-	if (segmentByChannel) {
-		// eslint-disable-next-line no-underscore-dangle
-		resultProjection.time = '$_id.time'
-		resultProjection.channelId = '$_id.channelId'
+	const resultProjection = {
+		value: '$value',
+		time: '$_id.time',
+		channelId: '$_id.channelId',
+		_id: 0
 	}
 
 	const pipeline = [

--- a/routes/analytics.js
+++ b/routes/analytics.js
@@ -110,6 +110,7 @@ function analytics(req, advertiserChannels, skipPublisherFiltering) {
 		{ $project: project },
 		{ $group: group },
 		{ $sort: { _id: 1, channelId: 1, created: 1 } },
+		{ $match: { value: { $gt: 0 } } },
 		{ $limit: appliedLimit },
 		{ $project: resultProjection }
 	]

--- a/routes/analytics.js
+++ b/routes/analytics.js
@@ -29,7 +29,7 @@ router.get('/advanced', validate, authRequired, notCached(advancedAnalytics))
 router.get('/:id', validate, channelIfExists, redisCached(600, analytics))
 router.get('/for-publisher/:id', validate, authRequired, channelIfExists, notCached(analytics))
 
-const MAX_LIMIT = 300
+const MAX_LIMIT = 500
 
 const MINUTE = 60 * 1000
 const HOUR = 60 * MINUTE

--- a/routes/analytics.js
+++ b/routes/analytics.js
@@ -29,6 +29,8 @@ router.get('/advanced', validate, authRequired, notCached(advancedAnalytics))
 router.get('/:id', validate, channelIfExists, redisCached(600, analytics))
 router.get('/for-publisher/:id', validate, authRequired, channelIfExists, notCached(analytics))
 
+const MAX_LIMIT = 300
+
 const MINUTE = 60 * 1000
 const HOUR = 60 * MINUTE
 const DAY = 24 * HOUR
@@ -88,7 +90,7 @@ function analytics(req, advertiserChannels, skipPublisherFiltering) {
 		metric,
 		skipPublisherFiltering
 	)
-	const appliedLimit = Math.min(200, limit)
+	const appliedLimit = Math.min(MAX_LIMIT, limit)
 	const timeGroup = {
 		$subtract: [{ $toLong: '$created' }, { $mod: [{ $toLong: '$created' }, span] }]
 	}


### PR DESCRIPTION
Minor changes, such as:

- not using mutable objects to simplify the query
- increased MAX_LIMIT
- segmentByChannel can be used in any case now
- researched perf impacts

Attaching a report regarding perf impacts:

```

const measure = x => {
	const n = Date.now()
	return [
		db.eventAggregates.aggregate(x).toArray(),
		Date.now() - n
	]
}

// Wrapping time in an object in _id
measure([{"$match":{"created":{"$gt":new Date("2020-01-11T22:30:45.897Z")}}},{"$project":{"created":1,"channelId":1,"value":{"$toLong":"$totals.CLICK.eventCounts"}}},{"$group":{"_id":{"time":{"$subtract":[{"$toLong":"$created"},{"$mod":[{"$toLong":"$created"},60000]}]}},"value":{"$sum":"$value"}}},{"$sort":{"_id":1,"channelId":1,"created":1}},{"$limit":100},{"$project":{"value":"$value","time":"$_id.time","channelId":"$_id.channelId","_id":0}}])
// 3723, 4097, 3762

// Original query
measure([{"$match":{"created":{"$gt":new Date("2020-01-11T22:30:45.897Z")}}},{"$project":{"created":1,"channelId":1,"value":{"$toLong":"$totals.CLICK.eventCounts"}}},{"$group":{"_id":{"$subtract":[{"$toLong":"$created"},{"$mod":[{"$toLong":"$created"},60000]}]},"value":{"$sum":"$value"}}},{"$sort":{"_id":1,"channelId":1,"created":1}},{"$limit":100},{"$project":{"value":"$value","time":"$_id","_id":0}}])
// 4219, 3848, 3733

// no noticable difference


// With channel grouping
measure([{"$match":{"created":{"$gt":new Date("2020-01-11T22:30:45.897Z")}}},{"$project":{"created":1,"channelId":1,"value":{"$toLong":"$totals.CLICK.eventCounts"}}},{"$group":{"_id":{"time":{"$subtract":[{"$toLong":"$created"},{"$mod":[{"$toLong":"$created"},60000]}]},"channelId":"$channelId"},"value":{"$sum":"$value"}}},{"$sort":{"_id":1,"channelId":1,"created":1}},{"$limit":100},{"$project":{"value":"$value","time":"$_id.time","channelId":"$_id.channelId","_id":0}}])
// 5280, 5913, 5822
// some degradation


// With channel grouping - nonzero
measure([{"$match":{"created":{"$gt":new Date("2020-01-11T22:30:45.897Z")}}},{"$project":{"created":1,"channelId":1,"value":{"$toLong":"$totals.CLICK.eventCounts"}}},{"$group":{"_id":{"time":{"$subtract":[{"$toLong":"$created"},{"$mod":[{"$toLong":"$created"},60000]}]},"channelId":"$channelId"},"value":{"$sum":"$value"}}},{"$sort":{"_id":1,"channelId":1,"created":1}},{"$match": {"value": {"$gt": 0}}},{"$limit":100},{"$project":{"value":"$value","time":"$_id.time","channelId":"$_id.channelId","_id":0}}])
// 5684, 5348, 5595

// New query - w/o channel grouping but nonzero
measure([{"$match":{"created":{"$gt":new Date("2020-01-11T22:30:45.897Z")}}},{"$project":{"created":1,"channelId":1,"value":{"$toLong":"$totals.CLICK.eventCounts"}}},{"$group":{"_id":{"time":{"$subtract":[{"$toLong":"$created"},{"$mod":[{"$toLong":"$created"},60000]}]}},"value":{"$sum":"$value"}}},{"$sort":{"_id":1,"channelId":1,"created":1}},{"$match": {"value": {"$gt": 0}}},{"$limit":100},{"$project":{"value":"$value","time":"$_id.time","channelId":"$_id.channelId","_id":0}}])
// 3905, 3698, 3877
```