### PR TITLE
WIP store a specHash property for channels upon submission

### DIFF
--- a/adapters/ethereum/index.js
+++ b/adapters/ethereum/index.js
@@ -203,7 +203,4 @@ async function testValidation() {
 testValidation().catch(e => console.error(e))
 */
 
-module.exports = {
-	Adapter,
-	toEthereumChannel
-}
+module.exports = { Adapter }

--- a/adapters/ethereum/index.js
+++ b/adapters/ethereum/index.js
@@ -6,7 +6,6 @@ const fetch = require('node-fetch')
 const util = require('util')
 const assert = require('assert')
 const fs = require('fs')
-const crypto = require('crypto')
 
 const readFile = util.promisify(fs.readFile)
 const lib = require('../lib')
@@ -161,17 +160,14 @@ Adapter.prototype.MerkleTree = MerkleTree
 // p.then(() => console.log(Date.now()-start))
 
 function toEthereumChannel(channel) {
-	const specHash = crypto
-		.createHash('sha256')
-		.update(JSON.stringify(channel.spec))
-		.digest()
+	assert.ok(typeof channel.specHash === 'string', 'channel.specHash required')
 	return new Channel({
 		creator: channel.creator,
 		tokenAddr: channel.depositAsset,
 		tokenAmount: channel.depositAmount,
 		validUntil: channel.validUntil,
 		validators: channel.spec.validators.map(v => v.id),
-		spec: specHash
+		spec: channel.specHash
 	})
 }
 

--- a/routes/channelCreate.js
+++ b/routes/channelCreate.js
@@ -13,7 +13,7 @@ function forAdapter(adapter) {
 		const channelsCol = db.getMongo().collection('channels')
 		const specHash = crypto
 			.createHash('sha256')
-			.update(JSON.stringify(channel.spec))
+			.update(JSON.stringify(req.body.spec))
 			.digest()
 		const channel = {
 			...req.body,

--- a/routes/channelCreate.js
+++ b/routes/channelCreate.js
@@ -1,5 +1,6 @@
 const express = require('express')
 const { celebrate } = require('celebrate')
+const crypto = require('crypto')
 const schema = require('./schemas')
 const db = require('../db')
 
@@ -10,9 +11,14 @@ function forAdapter(adapter) {
 	})
 	router.post('/', celebrate({ body: schema.createChannel }), function(req, res, next) {
 		const channelsCol = db.getMongo().collection('channels')
+		const specHash = crypto
+			.createHash('sha256')
+			.update(JSON.stringify(channel.spec))
+			.digest()
 		const channel = {
 			...req.body,
-			_id: req.body.id
+			_id: req.body.id,
+			specHash
 		}
 
 		adapter

--- a/test/ethereum/index.js
+++ b/test/ethereum/index.js
@@ -1,7 +1,9 @@
 const assert = require('assert')
+const crypto = require('crypto')
 const { ContractFactory, Contract, Wallet, providers } = require('ethers')
 const formatAddress = require('ethers').utils.getAddress
 
+const { Channel } = require('adex-protocol-eth/js')
 const adexCoreABI = require('adex-protocol-eth/abi/AdExCore.json')
 const adexCoreBytecode = require('adex-protocol-eth/resources/bytecode/AdExCore.json')
 const tokenbytecode = require('./token/tokenbytecode.json')
@@ -75,8 +77,24 @@ async function sampleChannel() {
 	}
 }
 
+function toEthereumChannel(channel) {
+	const specHash = crypto
+		.createHash('sha256')
+		.update(JSON.stringify(channel.spec))
+		.digest()
+	return new Channel({
+		creator: channel.creator,
+		tokenAddr: channel.depositAsset,
+		tokenAmount: channel.depositAmount,
+		validUntil: channel.validUntil,
+		validators: channel.spec.validators.map(v => v.id),
+		spec: specHash
+	})
+}
+
 module.exports = {
 	channelOpen,
 	deployContracts,
+	toEthereumChannel,
 	sampleChannel
 }

--- a/test/ethereum_adapter.js
+++ b/test/ethereum_adapter.js
@@ -4,9 +4,9 @@ const assert = require('assert')
 const { providers } = require('ethers')
 const { readFileSync } = require('fs')
 const formatAddress = require('ethers').utils.getAddress
-const { ethereum } = require('../adapters')
 const cfg = require('../cfg')
-const { channelOpen, deployContracts, sampleChannel } = require('./ethereum')
+const { ethereum } = require('../adapters')
+const { channelOpen, deployContracts, sampleChannel, toEthereumChannel } = require('./ethereum')
 const ewt = require('../adapters/ethereum/ewt')
 const fixtures = require('./fixtures')
 
@@ -165,7 +165,7 @@ tape('should not validate invalid channels', async function(t) {
 			provider
 		)
 		// ethereum representation
-		const ethChannel = ethereum.toEthereumChannel(channel)
+		const ethChannel = toEthereumChannel(channel)
 		channel.id = ethChannel.hashHex(core.address)
 
 		await tryCatchAsync(async () => ethAdapter.validateChannel(channel), err)
@@ -215,7 +215,7 @@ async function getValidChannel() {
 
 	// get a sample valid channel
 	const channel = await sampleChannel()
-	const ethChannel = ethereum.toEthereumChannel(channel)
+	const ethChannel = toEthereumChannel(channel)
 	channel.id = ethChannel.hashHex(core.address)
 
 	// cannot validate if its not onchain

--- a/test/lib.js
+++ b/test/lib.js
@@ -2,7 +2,7 @@ const fetch = require('node-fetch')
 const childproc = require('child_process')
 const ethers = require('ethers')
 const dummyVals = require('./prep-db/mongo')
-const { ethereum } = require('../adapters')
+const { toEthereumChannel } = require('./ethereum')
 
 const defaultPubName = dummyVals.ids.publisher
 
@@ -88,7 +88,7 @@ function getValidEthChannel() {
 		}
 	}
 
-	const ethChannel = ethereum.toEthereumChannel(channel)
+	const ethChannel = toEthereumChannel(channel)
 	// Just a hardcoded core addr is fine here; we don't need for more than the hash
 	const coreAddr = '0x333420fc6a897356e69b62417cd17ff012177d2b'
 	channel.id = ethChannel.hashHex(coreAddr)

--- a/test/routes.js
+++ b/test/routes.js
@@ -232,7 +232,11 @@ tape('POST /channel: create channel', async function(t) {
 		res.json()
 	)
 	t.ok(channelStatus.channel, 'has channelStatus.channel')
-	t.deepEqual(channelStatus.channel, channel, 'channel is the same')
+	t.deepEqual(
+		channelStatus.channel,
+		{ ...channel, specHash: channelStatus.channel.specHash },
+		'channel is the same'
+	)
 
 	const respFail = await fetchPost(`${followerUrl}/channel`, dummyVals.auth.leader, channel)
 	t.equal(respFail.status, 409, 'cannot submit the same channel twice')


### PR DESCRIPTION
fixes #278 

The goal of this is to enable easier calling of channel SC functions without having to compute the hash every time. Or if `spec` becomes accidently modified/corrupted.