### PR TITLE
Per-channel analytics should require auth, fixes #287

### DIFF
--- a/routes/analytics.js
+++ b/routes/analytics.js
@@ -27,7 +27,13 @@ router.get('/for-advertiser', validate, authRequired, notCached(advertiserAnalyt
 router.get('/advanced', validate, authRequired, notCached(advancedAnalytics))
 
 // :id is channelId: needs to be named that way cause of channelIfExists
-router.get('/:id', validate, authRequired, channelAdvertiserIfExists, redisCached(600, analytics))
+router.get(
+	'/:id',
+	validate,
+	authRequired,
+	channelAdvertiserIfExists,
+	redisCached(600, advertiserChannelAnalytics)
+)
 router.get('/for-publisher/:id', validate, authRequired, channelIfExists, notCached(analytics))
 
 const MAX_LIMIT = 500
@@ -135,6 +141,11 @@ function analytics(req, advertiserChannels, skipPublisherFiltering) {
 
 async function advertiserAnalytics(req) {
 	return analytics(req, await getAdvertiserChannels(req), true)
+}
+
+async function advertiserChannelAnalytics(req) {
+	delete req.session // don't segement by advertiser session uid
+	return analytics(req, undefined, undefined)
 }
 
 async function advancedAnalytics(req) {

--- a/test/lib.js
+++ b/test/lib.js
@@ -19,6 +19,17 @@ function fetchPost(url, authToken, body, headers = {}) {
 	})
 }
 
+function fetchWithAuth(url, authToken, headers = {}) {
+	return fetch(url, {
+		method: 'GET',
+		headers: {
+			authorization: `Bearer ${authToken}`,
+			'content-type': 'application/json',
+			...headers
+		}
+	})
+}
+
 function postEvents(url, channelId, events, auth = dummyVals.auth.creator, headers = {}) {
 	// It is important to use creator auth, otherwise we'd hit rate limits
 	return fetchPost(`${url}/channel/${channelId}/events`, auth, { events }, headers)
@@ -114,5 +125,6 @@ module.exports = {
 	validUntil,
 	withdrawPeriodStart,
 	getValidEthChannel,
-	randomAddress
+	randomAddress,
+	fetchWithAuth
 }


### PR DESCRIPTION
The channel analytics now require that the channel creator (advertiser) authenticates.

This fixes 3 distinct issues:
* #287: advertiser analytics per channel must require auth
* calling this path with authentication actually caused earning (publisher) stats to be retrieved for this channel - leading to zero results for almost all channels except the one where the creator is both an advertiser and publisher
* calling this path with authentication will cause it to be cached in the same cache key as every other call to it, leading to results for different callers being served