### PR TITLE
Analytics time groups fix

### DIFF
--- a/routes/analytics.js
+++ b/routes/analytics.js
@@ -17,7 +17,9 @@ const notCached = fn => (req, res, next) =>
 	fn(req)
 		.then(res.json.bind(res))
 		.catch(next)
-const validate = celebrate({ query: { ...schemas.eventTimeAggr, segmentByChannel: Joi.string() } })
+const validate = celebrate({
+	query: { ...schemas.eventTimeAggr, segmentByChannel: Joi.string(), timezone: Joi.string() }
+})
 
 const isAdmin = (req, res, next) => {
 	if (cfg.admins.includes(req.session.uid)) {
@@ -137,7 +139,7 @@ function getProjAndMatch(channelMatch, start, end, eventType, metric, earner) {
 
 function analytics(req, advertiserChannels, earner) {
 	// default is applied via validation schema
-	const { limit, timeframe, eventType, metric, start, end, segmentByChannel } = req.query
+	const { limit, timeframe, eventType, metric, start, end, segmentByChannel, timezone } = req.query
 
 	const { period, span } = getTimeframe(timeframe)
 
@@ -178,7 +180,7 @@ function analytics(req, advertiserChannels, earner) {
 					day: { $ifNull: ['$_id.time.day', 1] },
 					hour: { $ifNull: ['$_id.time.hour', 0] },
 					minute: { $ifNull: ['$_id.time.minute', 0] },
-					timezone: 'UTC'
+					timezone: timezone || 'UTC'
 				}
 			}
 		},

--- a/routes/analytics.js
+++ b/routes/analytics.js
@@ -80,6 +80,10 @@ function getTimeframe(timeframe, weekHoursSpan) {
 	return { period: DAY, span: HOUR }
 }
 
+// NOTE: optimized was looking like that `($subtract: [{ $toLong: '$created' }, { $mod: [{ $toLong: '$created' }, span] }])`
+// Year timeframe groups (month start) was not correct - leap years + there was no timezones
+// Its slower now - more info at https://github.com/AdExNetwork/adex-validator/pull/312
+// and https://gist.github.com/IvoPaunov/1b23223b558ae4b8b6d2ba4ac408919f
 function getTimeGroup(timeframe, weekHoursSpan) {
 	if (timeframe === 'month') {
 		return { year: `$year`, month: `$month`, day: `$day` }

--- a/routes/analytics.js
+++ b/routes/analytics.js
@@ -63,7 +63,7 @@ function getTimeframe(timeframe) {
 	// every day in one month
 	if (timeframe === 'month') return { period: ROUGH_MONTH, span: DAY }
 	// every 6 hours in a week
-	if (timeframe === 'week') return { period: 7 * DAY, span: 6 * HOUR }
+	if (timeframe === 'week') return { period: 7 * DAY, span: 3 * HOUR }
 	// every hour in one day
 	if (timeframe === 'day') return { period: DAY, span: HOUR }
 	// every minute in an hour
@@ -83,7 +83,7 @@ function getTimeGroup(timeframe, prefix = '') {
 			year: `$${prefix}year`,
 			month: `$${prefix}month`,
 			day: `$${prefix}day`,
-			hour: { $multiply: [{ $floor: { $divide: [`$${prefix}hour`, 6] } }, 6] }
+			hour: { $multiply: [{ $floor: { $divide: [`$${prefix}hour`, 3] } }, 3] }
 		}
 	}
 

--- a/routes/analytics.js
+++ b/routes/analytics.js
@@ -112,7 +112,7 @@ function getTimeGroup(timeframe, prefix = '') {
 }
 
 function getProjAndMatch(channelMatch, start, end, eventType, metric, earner) {
-	const timeMatch = end ? { created: { $lte: end, $gt: start } } : { created: { $gt: start } }
+	const timeMatch = end ? { created: { $lte: end, $gte: start } } : { created: { $gte: start } }
 	let publisherId = null
 	if (earner) {
 		publisherId = toBalancesKey(earner)
@@ -126,11 +126,11 @@ function getProjAndMatch(channelMatch, start, end, eventType, metric, earner) {
 		created: 1,
 		channelId: 1,
 		value: projectValue,
-		year: { $year: { date: '$created', timezone: '+00:00' } },
-		month: { $month: { date: '$created', timezone: '+00:00' } },
-		day: { $dayOfMonth: { date: '$created', timezone: '+00:00' } },
-		hour: { $hour: { date: '$created', timezone: '+00:00' } },
-		minute: { $minute: { date: '$created', timezone: '+00:00' } }
+		year: { $year: '$created' },
+		month: { $month: '$created' },
+		day: { $dayOfMonth: '$created' },
+		hour: { $hour: '$created' },
+		minute: { $minute: '$created' }
 	}
 	return { match, project }
 }
@@ -178,7 +178,7 @@ function analytics(req, advertiserChannels, earner) {
 					day: { $ifNull: ['$_id.time.day', 1] },
 					hour: { $ifNull: ['$_id.time.hour', 0] },
 					minute: { $ifNull: ['$_id.time.minute', 0] },
-					timezone: '+00:00'
+					timezone: 'UTC'
 				}
 			}
 		},

--- a/routes/analytics.js
+++ b/routes/analytics.js
@@ -100,11 +100,15 @@ function getTimeGroup(timeframe, prefix = '') {
 			month: `$${prefix}month`,
 			day: `$${prefix}day`,
 			hour: `$${prefix}hour`,
-			minutes: `$${prefix}minutes`
+			minute: `$${prefix}minute`
 		}
 	}
 
-	return { year: '$year', month: `$${prefix}month` }
+	if (timeframe === 'year') {
+		return { year: `$${prefix}year`, month: `$${prefix}month` }
+	}
+
+	return { year: '$year' }
 }
 
 function getProjAndMatch(channelMatch, start, end, eventType, metric, earner) {
@@ -122,12 +126,11 @@ function getProjAndMatch(channelMatch, start, end, eventType, metric, earner) {
 		created: 1,
 		channelId: 1,
 		value: projectValue,
-		year: { $year: '$created' },
-		month: { $month: '$created' },
-		week: { $week: '$created' },
-		day: { $dayOfMonth: '$created' },
-		hour: { $hour: '$created' },
-		minutes: { $minute: '$created' }
+		year: { $year: { date: '$created', timezone: '+00:00' } },
+		month: { $month: { date: '$created', timezone: '+00:00' } },
+		day: { $dayOfMonth: { date: '$created', timezone: '+00:00' } },
+		hour: { $hour: { date: '$created', timezone: '+00:00' } },
+		minute: { $minute: { date: '$created', timezone: '+00:00' } }
 	}
 	return { match, project }
 }
@@ -171,10 +174,11 @@ function analytics(req, advertiserChannels, earner) {
 			$toLong: {
 				$dateFromParts: {
 					year: { $ifNull: ['$_id.time.year', 0] },
-					month: { $ifNull: ['$_id.time.month', 0] },
-					day: { $ifNull: ['$_id.time.day', 0] },
+					month: { $ifNull: ['$_id.time.month', 1] },
+					day: { $ifNull: ['$_id.time.day', 1] },
 					hour: { $ifNull: ['$_id.time.hour', 0] },
-					minute: { $ifNull: ['$_id.time.minutes', 0] }
+					minute: { $ifNull: ['$_id.time.minute', 0] },
+					timezone: '+00:00'
 				}
 			}
 		},

--- a/routes/analytics.js
+++ b/routes/analytics.js
@@ -73,41 +73,41 @@ function getTimeframe(timeframe) {
 	return { period: DAY, span: HOUR }
 }
 
-function getTimeGroup(timeframe, prefix = '') {
+function getTimeGroup(timeframe) {
 	if (timeframe === 'month') {
-		return { year: `$${prefix}year`, month: `$${prefix}month`, day: `$${prefix}day` }
+		return { year: `$year`, month: `$month`, day: `$day` }
 	}
 
 	if (timeframe === 'week') {
 		return {
-			year: `$${prefix}year`,
-			month: `$${prefix}month`,
-			day: `$${prefix}day`,
-			hour: { $multiply: [{ $floor: { $divide: [`$${prefix}hour`, 3] } }, 3] }
+			year: `$year`,
+			month: `$month`,
+			day: `$day`,
+			hour: { $multiply: [{ $floor: { $divide: [`$hour`, 3] } }, 3] }
 		}
 	}
 
 	if (timeframe === 'day') {
 		return {
-			year: `$${prefix}year`,
-			month: `$${prefix}month`,
-			day: `$${prefix}day`,
-			hour: `$${prefix}hour`
+			year: `$year`,
+			month: `$month`,
+			day: `$day`,
+			hour: `$hour`
 		}
 	}
 
 	if (timeframe === 'hour') {
 		return {
-			year: `$${prefix}year`,
-			month: `$${prefix}month`,
-			day: `$${prefix}day`,
-			hour: `$${prefix}hour`,
-			minute: `$${prefix}minute`
+			year: `$year`,
+			month: `$month`,
+			day: `$day`,
+			hour: `$hour`,
+			minute: `$minute`
 		}
 	}
 
 	if (timeframe === 'year') {
-		return { year: `$${prefix}year`, month: `$${prefix}month` }
+		return { year: `$year`, month: `$month` }
 	}
 
 	return { year: '$year' }

--- a/routes/analytics.js
+++ b/routes/analytics.js
@@ -73,18 +73,19 @@ function getTimeframe(timeframe) {
 
 function getTimeGroup(timeframe, prefix = '') {
 	if (timeframe === 'month') {
-		return { year: `$${prefix}year`, month: `$${prefix}month` }
-	}
-
-	if (timeframe === 'week') {
-		return { year: `$${prefix}year`, week: `$${prefix}week` }
-	}
-
-	if (timeframe === 'day') {
 		return { year: `$${prefix}year`, month: `$${prefix}month`, day: `$${prefix}day` }
 	}
 
-	if (timeframe === 'hour') {
+	if (timeframe === 'week') {
+		return {
+			year: `$${prefix}year`,
+			month: `$${prefix}month`,
+			day: `$${prefix}day`,
+			hour: { $multiply: [{ $floor: { $divide: [`$${prefix}hour`, 6] } }, 6] }
+		}
+	}
+
+	if (timeframe === 'day') {
 		return {
 			year: `$${prefix}year`,
 			month: `$${prefix}month`,
@@ -93,10 +94,9 @@ function getTimeGroup(timeframe, prefix = '') {
 		}
 	}
 
-	if (timeframe === 'minute') {
+	if (timeframe === 'hour') {
 		return {
 			year: `$${prefix}year`,
-			week: `$${prefix}week`,
 			month: `$${prefix}month`,
 			day: `$${prefix}day`,
 			hour: `$${prefix}hour`,
@@ -104,7 +104,7 @@ function getTimeGroup(timeframe, prefix = '') {
 		}
 	}
 
-	return { year: '$year' }
+	return { year: '$year', month: `$${prefix}month` }
 }
 
 function getProjAndMatch(channelMatch, start, end, eventType, metric, earner) {
@@ -170,11 +170,11 @@ function analytics(req, advertiserChannels, earner) {
 		time: {
 			$toLong: {
 				$dateFromParts: {
-					year: '$_id.time.year',
-					month: '$_id.time.month',
-					day: '$_id.time.day',
-					hour: '$_id.time.hour',
-					minute: '$_id.time.minute'
+					year: { $ifNull: ['$_id.time.year', 0] },
+					month: { $ifNull: ['$_id.time.month', 0] },
+					day: { $ifNull: ['$_id.time.day', 0] },
+					hour: { $ifNull: ['$_id.time.hour', 0] },
+					minute: { $ifNull: ['$_id.time.minutes', 0] }
 				}
 			}
 		},


### PR DESCRIPTION
* fixes /analytics time period groups https://github.com/AdExNetwork/adex-validator/issues/310
* /analytics week timeframe span from 6 to 3 hours
* /analytics - added `timezone` query prop

It's slower 
`for-advertiser` timeframe year x2 slower, other timeframes ~10% slower - based on adex account 300M+ impressions for past year
`fro-publisher` almost identical times ~5-10% - based on publisher with 100M+for the past year

More query time data: https://gist.github.com/IvoPaunov/1b23223b558ae4b8b6d2ba4ac408919f
