### PR TITLE
add extra rewards data to incentives distribute record

### DIFF
--- a/scripts/distribute-incentives.js
+++ b/scripts/distribute-incentives.js
@@ -259,8 +259,10 @@ async function main() {
 		signatures: [balancesSig, balancesSig],
 		periodStart: DISTRIBUTION_STARTS,
 		periodEnd: DISTRIBUTION_ENDS,
-		currentRewardPerSecond,
-		currentTotalActiveStake
+		stats: {
+			currentRewardPerSecond,
+			currentTotalActiveStake
+		}
 	}
 	await rewardChannels.updateOne({ _id: channelId }, { $set: rewardRecord }, { upsert: true })
 


### PR DESCRIPTION
- adds `currentRewardPerSecond and currentTotalActiveStake` values to reward records for the incentive rewards distribution. The data is used for correct calculation of the current APY https://github.com/AdExNetwork/adex-staking/issues/47
